### PR TITLE
Replacing outdated distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from distutils.core import Command, setup
+from setuptools import Command, setup
 import unittest
 
 UNITTESTS = [


### PR DESCRIPTION
`distutils` is outdated and there's no reason to use it over `setuptools`, so to keep this package up to date I suggest replacing `distutils` with `setuptools` :)

distutils can't build eggs :(